### PR TITLE
[Optimize]: Support gn command with android target on windows.

### DIFF
--- a/config/BUILDCONFIG.gn
+++ b/config/BUILDCONFIG.gn
@@ -73,6 +73,10 @@ if (current_cpu == "") {
 if (current_os == "") {
   if (host_os == "win") {
     current_os = "win"
+    # support android build on windows
+    if (target_os == "android") {
+      current_os = target_os
+    }
   } else {
     current_os = target_os
   }

--- a/config/android/BUILD.gn
+++ b/config/android/BUILD.gn
@@ -18,15 +18,16 @@ config("sdk") {
       }
     }
     
-
-    # Need to get some linker flags out of the sysroot.
-    sysroot_ld_path = rebase_path("//build/config/linux/sysroot_ld_path.py")
-    ldflags += [ exec_script(sysroot_ld_path,
+    if (host_os != "win") {
+      # Need to get some linker flags out of the sysroot.
+      sysroot_ld_path = rebase_path("//build/config/linux/sysroot_ld_path.py")
+      ldflags += [ exec_script(sysroot_ld_path,
                              [
                                rebase_path("//build/linux/sysroot_ld_path.sh"),
                                sysroot,
                              ],
                              "value") ]
+    }
   }
 }
 

--- a/config/android/config.gni
+++ b/config/android/config.gni
@@ -126,7 +126,7 @@ if (is_android) {
   } else if (host_os == "mac") {
     android_host_os = "darwin"
   } else if (host_os == "win") {
-    android_host_os = "win"
+    android_host_os = "windows"
   } else {
     assert(false, "Need Android toolchain support for your build OS.")
   }

--- a/toolchain/android/BUILD.gn
+++ b/toolchain/android/BUILD.gn
@@ -60,6 +60,8 @@ template("android_gcc_toolchain") {
         host_dir = "linux-x86_64"
       } else if (host_os == "mac") {
         host_dir = "darwin-x86_64"
+      } else if (host_os == "win") {
+        host_dir ="windows-x86_64"
       } else {
         assert(false, "Unknown host")
       }


### PR DESCRIPTION
Adapt buildroot with android target on windows to run gn command successfully on windows with android. After this change, gn gen command can be successfully executed with target_os=android args on windows. Notice: this change only makes it possible to run gn command, but ninja will failed due to wrong commands or toolchain options, like touch command or -gD ld options.