### PR TITLE
[Build] Fixed Python script errors, fix GYP_MSVS_OVERRIDE_PATH 

### DIFF
--- a/toolchain/win/setup_toolchain.py
+++ b/toolchain/win/setup_toolchain.py
@@ -128,6 +128,8 @@ def main():
 
   # TODO(scottmg|goma): Do we need an equivalent of
   # ninja_use_custom_environment_files?
+  if not ('GYP_MSVS_OVERRIDE_PATH' in os.environ and os.environ['GYP_MSVS_OVERRIDE_PATH'].strip()):
+    os.environ['GYP_MSVS_OVERRIDE_PATH'] = visual_studio_path
 
   for cpu in cpus:
     # Extract environment variables for subprocesses.


### PR DESCRIPTION
Fixed Python script errors, ensuring compatibility when the environment variable GYP_MSVS_OVERRIDE_PATH is missing.